### PR TITLE
Add storages imports

### DIFF
--- a/aiogram_media_group/__init__.py
+++ b/aiogram_media_group/__init__.py
@@ -14,3 +14,4 @@ elif AIOGRAM_VERSION == 2:
     MediaGroupFilter = lambda: AiogramMediaGroupFilter(is_media_group=True)
 
 from .handler import media_group_handler
+from . import storages

--- a/aiogram_media_group/storages/__init__.py
+++ b/aiogram_media_group/storages/__init__.py
@@ -1,0 +1,3 @@
+from .base import BaseStorage
+from .redis import RedisStorage
+from .memory import MemoryStorage


### PR DESCRIPTION
Added storages imports, so now it can be used like this:

`from aiogram_media_group import media_group_handler, storages`

`@media_group_handler(storage_driver=storages.MemoryStorage(data={}, prefix="aiogram_media_group")`